### PR TITLE
修改抓取依赖网站为https://search.maven.org, 参见:#3

### DIFF
--- a/src/actions/MavenDependencyHelperAction.java
+++ b/src/actions/MavenDependencyHelperAction.java
@@ -1,41 +1,43 @@
 package actions;
 
-import com.intellij.openapi.actionSystem.*;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.CommonDataKeys;
+import com.intellij.openapi.actionSystem.LangDataKeys;
 import com.intellij.openapi.editor.Caret;
 import com.intellij.openapi.editor.CaretModel;
-import com.intellij.openapi.project.Project;
+import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.ui.ComboBox;
 import com.intellij.psi.PsiFile;
 import com.intellij.ui.components.JBList;
 import com.intellij.ui.components.JBScrollPane;
+import model.Artifact;
 import model.Dependency;
+import org.dom4j.Document;
+import org.dom4j.DocumentException;
+import org.dom4j.Element;
+import org.dom4j.io.SAXReader;
 import org.jetbrains.annotations.NotNull;
+import searcher.DependencySearcher;
+import searcher.SearchMavenOrgDependencySearcher;
 
+import javax.swing.*;
 import java.awt.*;
 import java.awt.datatransfer.Clipboard;
 import java.awt.datatransfer.StringSelection;
 import java.awt.event.*;
-import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.*;
-import java.util.stream.Collectors;
-
-import org.dom4j.*;
-import org.dom4j.io.*;
-import org.jsoup.Jsoup;
-import org.jsoup.select.Elements;
-
-import javax.swing.*;
 
 /**
  * @author yiyingcanfeng
  */
 public class MavenDependencyHelperAction extends AnAction {
-
-    private List<Dependency> dependencies = new ArrayList<>();
 
     private JFrame frame;
     private JTextArea textArea;
@@ -44,107 +46,58 @@ public class MavenDependencyHelperAction extends AnAction {
     private JButton searchButton;
     private JComboBox<String> comboBox;
     private JComboBox<String> typeComboBox;
-    private JLabel titleLabel;
     private JTextField textField;
     private JBScrollPane scrollPane;
     private JList<String> versionJList;
     private DefaultListModel<String> versionListModel;
     private JScrollPane listScroller;
 
-    private String selectedText;
     private String groupId;
     private String artifactId;
     private String version;
     private String scope;
 
     private ThreadPoolExecutor threadPool;
+    private DependencySearcher dependencySearcher;
 
     @Override
     public void actionPerformed(@NotNull AnActionEvent e) {
-        //获取当前操作的类文件
-        PsiFile psiFile = e.getData(CommonDataKeys.PSI_FILE);
-        //获取当前文件的路径
-        String filePath = psiFile != null ? psiFile.getVirtualFile().getPath() : "";
-        //获取选中的文本
-        CaretModel caretModel = Objects.requireNonNull(e.getData(LangDataKeys.EDITOR)).getCaretModel();
-        Caret currentCaret = caretModel.getCurrentCaret();
-        selectedText = currentCaret.getSelectedText() != null ? currentCaret.getSelectedText() : "";
-        dependencies = getDependencies(filePath);
-        //初始化线程池
         ThreadFactory threadFactory = Executors.defaultThreadFactory();
-        threadPool = new ThreadPoolExecutor(3, 5, 10, TimeUnit.SECONDS, new ArrayBlockingQueue<>(2), threadFactory);
-        if (!"".equals(selectedText) && dependencies.size() > 0) {
-            //从List<Dependency>中搜索选中的Dependency，并获取其详细信息
-            List<Dependency> list = dependencies.stream().filter(item -> item.getArtifactId().equals(selectedText)).collect(Collectors.toList());
-            if (list.size() > 0) {
-                Dependency dependency = list.get(0);
-                groupId = dependency.getGroupId();
-                artifactId = dependency.getArtifactId();
-                scope = dependency.getScope();
-                initView();
-                getVersionsAndShow();
-            } else {
-                groupId = "";
-                artifactId = "";
-                scope = "";
-                initView();
-                getVersionsAndShow();
+        this.threadPool = new ThreadPoolExecutor(3, 5, 10, TimeUnit.SECONDS, new ArrayBlockingQueue<>(2), threadFactory);
+        this.dependencySearcher = new SearchMavenOrgDependencySearcher();
+        this.groupId = "";
+        this.artifactId = "";
+        this.version = "";
+        this.scope = "";
+
+        // 获取选中文本匹配的依赖
+        Editor editor = e.getData(LangDataKeys.EDITOR);
+        if (editor != null) {
+            CaretModel caretModel = editor.getCaretModel();
+            Caret currentCaret = caretModel.getCurrentCaret();
+            String selectedText = currentCaret.getSelectedText() != null ? currentCaret.getSelectedText().trim() : "";
+            if (selectedText.length() > 0) {
+                PsiFile psiFile = e.getData(CommonDataKeys.PSI_FILE);
+                String filePath = psiFile != null ? psiFile.getVirtualFile().getPath() : "";
+                List<Dependency> dependencies = getDependenciesByPom(filePath);
+                Optional<Dependency> matchDependencyOpt = dependencies.stream()
+                        .filter(item -> selectedText.equals(item.getArtifactId()))
+                        .findFirst();
+                if (matchDependencyOpt.isPresent()) {
+                    Dependency dependency = matchDependencyOpt.get();
+                    this.groupId = dependency.getGroupId() == null ? "" : dependency.getGroupId();
+                    this.artifactId = dependency.getArtifactId() == null ? "" : dependency.getArtifactId();
+                }
             }
-        } else {
-            groupId = "";
-            artifactId = "";
-            scope = "";
-            initView();
         }
 
-    }
-
-    /**
-     * 获取versions并展示
-     */
-    private void getVersionsAndShow() {
-        copyVersionButton.setText("loading...");
-        threadPool.execute(() -> {
-            long start = System.currentTimeMillis();
-            try {
-                Elements elementsByClass = getReleaseVersionElements();
-                SwingUtilities.invokeLater(() -> {
-                    copyVersionButton.setText("Copy Version");
-                    addToVersionListModel(elementsByClass);
-                });
-            } catch (IOException e1) {
-                e1.printStackTrace();
-            }
-            long end = System.currentTimeMillis();
-            System.out.println("网络请求耗时:" + (end - start));
-
-        });
-    }
-
-    /**
-     * 获取release类型的依赖信息
-     *
-     * @return Elements
-     * @throws IOException IOException
-     */
-    private Elements getReleaseVersionElements() throws IOException {
-        String url = String.format("https://mvnrepository.com/artifact/%s/%s", groupId, artifactId);
-        org.jsoup.nodes.Document doc = Jsoup.connect(url).get();
-        return doc.getElementsByClass("vbtn release");
-    }
-
-    /**
-     * 向ListModel中添加version信息
-     *
-     * @param elementsByClass Elements
-     */
-    private void addToVersionListModel(Elements elementsByClass) {
-        for (org.jsoup.nodes.Element byClass : elementsByClass) {
-            String href = byClass.attr("href");
-            String version = href.split("/")[1];
-            versionListModel.addElement(version);
+        initView();
+        if (this.groupId.length() > 0 && this.artifactId.length() > 0) {
+            loadDependencyVersionsView();
         }
     }
+
+    //------------------ UI渲染 ------------------ //
 
     /**
      * 初始化界面
@@ -191,8 +144,6 @@ public class MavenDependencyHelperAction extends AnAction {
         textArea.setRows(6);
         textArea.setFont(new Font(null, Font.PLAIN, 16));
 
-        titleLabel = new JLabel(artifactId);
-        titleLabel.setFont(new Font(null, Font.PLAIN, 16));
         textField = new JTextField();
         textField.setFont(new Font(null, Font.PLAIN, 16));
 
@@ -262,84 +213,74 @@ public class MavenDependencyHelperAction extends AnAction {
         frame.setVisible(true);
     }
 
+    //------------------ 事件 ------------------ //
+
     /**
      * 搜索依赖
      */
     private void search() {
         String text = textField.getText();
         searchButton.setText("Searching...");
-        String searchUrl = "https://mvnrepository.com/search?q=" + text;
         threadPool.execute(() -> {
             try {
-                org.jsoup.nodes.Document doc = Jsoup.connect(searchUrl).get();
-                doc = Jsoup.parse(doc.getElementsByClass("im-subtitle").html());
-                String[] split = doc.getElementsByAttribute("href").text().split(" ");
-                String firstGroupId = split[0];
-                String firstArtifactId = split[1];
-                groupId = split[0];
-                artifactId = split[1];
-                try {
-                    String url = String.format("https://mvnrepository.com/artifact/%s/%s", firstGroupId, firstArtifactId);
-                    org.jsoup.nodes.Document doc1 = Jsoup.connect(url).get();
-                    Elements elementsByClass = doc1.getElementsByClass("vbtn release");
+                List<Artifact> artifacts = dependencySearcher.search(text);
+                if (artifacts.size() == 0) {
                     SwingUtilities.invokeLater(() -> {
                         comboBox.removeAllItems();
-                        for (int i = 0; i < split.length; i += 2) {
-                            comboBox.addItem(split[i] + "/" + split[i + 1]);
-                        }
-                        searchButton.setText("Search");
-                        titleLabel.setText(firstArtifactId);
                         versionListModel.removeAllElements();
-                        for (org.jsoup.nodes.Element byClass : elementsByClass) {
-                            String href = byClass.attr("href");
-                            String[] version = href.split("/");
-                            versionListModel.addElement(version[1]);
-                        }
+                        searchButton.setText("Search");
+                        textArea.setText("");
                     });
-                } catch (IOException e1) {
-                    e1.printStackTrace();
+                    return;
                 }
+                Artifact firstArtifact = artifacts.get(0);
+                this.groupId = firstArtifact.getGroupId();
+                this.artifactId = firstArtifact.getArtifactId();
+                List<Dependency> dependencies = dependencySearcher.getDependencies(this.groupId, this.artifactId);
 
+                SwingUtilities.invokeLater(() -> {
+                    comboBox.removeAllItems();
+                    for (Artifact one : artifacts) {
+                        comboBox.addItem(one.getGroupId() + "/" + one.getArtifactId());
+                    }
+                    versionListModel.removeAllElements();
+                    for (Dependency one : dependencies) {
+                        versionListModel.addElement(one.getVersion());
+                    }
+                    if (versionListModel.size() > 0) {
+                        versionJList.setSelectedIndex(0);
+                    } else {
+                        textArea.setText("");
+                    }
+                    searchButton.setText("Search");
+                });
             } catch (IOException e1) {
                 e1.printStackTrace();
+            } catch (Exception e) {
+                e.printStackTrace();
             }
         });
     }
 
     /**
-     * 读取并解析pom.xml，获取Dependency信息
-     *
-     * @param filePath 文件名
-     * @return List<Dependency>
+     * 重新加载版本视图
      */
-    private List<Dependency> getDependencies(String filePath) {
-        List<Dependency> d = new ArrayList<>();
-        if (filePath.contains("pom.xml")) {
-            File file = new File(filePath);
+    private void loadDependencyVersionsView() {
+        copyVersionButton.setText("Loading...");
+        threadPool.execute(() -> {
             try {
-                SAXReader saxReader = new SAXReader();
-                Document document = saxReader.read(file);
-                Element rootElement = document.getRootElement();
-                Element dependenciesElement = rootElement.element("dependencies");
-                for (Iterator it = dependenciesElement.elementIterator(); it.hasNext(); ) {
-                    Dependency dependency = new Dependency();
-                    Element element = (Element) it.next();
-                    String groupId = element.element("groupId").getText();
-                    String artifactId = element.element("artifactId").getText();
-                    String version = element.element("version") == null ? "" : element.element("version").getText();
-                    String scope = element.element("scope") == null ? "" : element.element("scope").getText();
-                    dependency.setGroupId(groupId);
-                    dependency.setArtifactId(artifactId);
-                    dependency.setVersion(version);
-                    dependency.setScope(scope);
-                    d.add(dependency);
-                }
-
-            } catch (DocumentException e) {
+                List<Dependency> dependencies = dependencySearcher.getDependencies(this.groupId, this.artifactId);
+                SwingUtilities.invokeLater(() -> {
+                    versionListModel.removeAllElements();
+                    for (Dependency dependency : dependencies) {
+                        versionListModel.addElement(dependency.getVersion());
+                    }
+                    copyVersionButton.setText("Copy Version");
+                });
+            } catch (IOException e) {
                 e.printStackTrace();
             }
-        }
-        return d;
+        });
     }
 
     /**
@@ -350,38 +291,9 @@ public class MavenDependencyHelperAction extends AnAction {
     private void comboBoxItemSelectEvent(ItemEvent event) {
         if (event.getStateChange() == ItemEvent.SELECTED) {
             String[] itemStringSplit = event.getItem().toString().split("/");
-            groupId = itemStringSplit[0];
-            artifactId = itemStringSplit[1];
-            copyVersionButton.setText("Loading...");
-            threadPool.execute(() -> {
-                try {
-                    Elements elementsByClass = getReleaseVersionElements();
-                    //根据第一个依赖信息，在mvnrepository网站该依赖的详情页面查询该依赖是否有scope属性，比如javaee-api有provided属性，junit有test属性，如果没有，则后面生成的dependencyText就不带scope属性
-                    String firstVersion = elementsByClass.get(0).attr("href").split("/")[1];
-                    String url1 = String.format("https://mvnrepository.com/artifact/%s/%s/%s", groupId, artifactId, firstVersion);
-                    org.jsoup.nodes.Document doc2 = Jsoup.connect(url1).get();
-                    org.jsoup.nodes.Element element = doc2.getElementById("maven-div");
-                    String configContent = element.child(0).html();
-                    configContent = configContent.replace("&lt;", "<").replace("&gt;", ">");
-                    SAXReader saxReader = new SAXReader();
-                    Document document = saxReader.read(new ByteArrayInputStream(configContent.getBytes()));
-                    Element rootElement = document.getRootElement();
-                    if (rootElement.element("scope") != null) {
-                        scope = rootElement.element("scope").getData().toString();
-                    } else {
-                        scope = "";
-                    }
-                    SwingUtilities.invokeLater(() -> {
-                        versionListModel.removeAllElements();
-                        addToVersionListModel(elementsByClass);
-                        copyVersionButton.setText("Copy Version");
-                    });
-                } catch (IOException | DocumentException e) {
-                    e.printStackTrace();
-                }
-
-            });
-
+            this.groupId = itemStringSplit[0];
+            this.artifactId = itemStringSplit[1];
+            loadDependencyVersionsView();
         }
     }
 
@@ -395,39 +307,8 @@ public class MavenDependencyHelperAction extends AnAction {
             //JList为空时，点击其空白区域仍会触发点击事件
             Object selectedValue = jList.getSelectedValue();
             version = selectedValue == null ? "" : selectedValue.toString();
-            String dependencyText;
             String type = typeComboBox.getSelectedItem().toString();
-            switch (type) {
-                case "Maven":
-                    if ("".equals(scope)) {
-                        dependencyText = "<dependency>\n" +
-                                "    <groupId>" + groupId + "</groupId>\n" +
-                                "    <artifactId>" + artifactId + "</artifactId>\n" +
-                                "    <version>" + version + "</version>\n" +
-                                "</dependency>";
-                    } else {
-                        dependencyText = "<dependency>\n" +
-                                "    <groupId>" + groupId + "</groupId>\n" +
-                                "    <artifactId>" + artifactId + "</artifactId>\n" +
-                                "    <version>" + version + "</version>\n" +
-                                "    <scope>" + scope + "</scope>\n" +
-                                "</dependency>";
-                    }
-
-                    break;
-                case "Gradle":
-                    dependencyText = dependencyTextForGradle();
-                    break;
-                default:
-                    dependencyText = "<dependency>\n" +
-                            "    <groupId>" + groupId + "</groupId>\n" +
-                            "    <artifactId>" + artifactId + "</artifactId>\n" +
-                            "    <version>" + version + "</version>\n" +
-                            "</dependency>";
-                    break;
-            }
-
-
+            String dependencyText = dependencyTextByType(type);
             textArea.setText(dependencyText);
             //copyVersion按钮点击事件
             copyVersionButton.addMouseListener(new MouseAdapter() {
@@ -467,7 +348,6 @@ public class MavenDependencyHelperAction extends AnAction {
             });
             //依赖类型ComboBox Item事件
             typeComboBox.addItemListener(this::typeComboBoxItemSelectEvent);
-
         }
 
         /**
@@ -476,49 +356,94 @@ public class MavenDependencyHelperAction extends AnAction {
          */
         private void typeComboBoxItemSelectEvent(ItemEvent event) {
             if (event.getStateChange() == ItemEvent.SELECTED) {
-                String itemString = event.getItem().toString();
-                String dependencyText;
-                if ("Maven".equals(itemString)) {
-                    if ("".equals(scope)) {
-                        dependencyText = "<dependency>\n" +
-                                "    <groupId>" + groupId + "</groupId>\n" +
-                                "    <artifactId>" + artifactId + "</artifactId>\n" +
-                                "    <version>" + version + "</version>\n" +
-                                "</dependency>";
-                    } else {
-                        dependencyText = "<dependency>\n" +
-                                "    <groupId>" + groupId + "</groupId>\n" +
-                                "    <artifactId>" + artifactId + "</artifactId>\n" +
-                                "    <version>" + version + "</version>\n" +
-                                "    <scope>" + scope + "</scope>\n" +
-                                "</dependency>";
-                    }
-
-                } else if ("Gradle".equals(itemString)) {
-                    dependencyText = dependencyTextForGradle();
-                } else {
-                    dependencyText = "";
-                }
-
+                String buildToolType = event.getItem().toString();
+                String dependencyText = dependencyTextByType(buildToolType);
                 textArea.setText(dependencyText);
             }
         }
     };
 
-    //生成gradle的依赖文本
+    //------------------ 辅助方法 ------------------ //
+
+    /**
+     * 读取并解析pom.xml，获取Dependency信息
+     */
+    private List<Dependency> getDependenciesByPom(String filePath) {
+        List<Dependency> d = new ArrayList<>();
+        if (filePath.contains("pom.xml")) {
+            File file = new File(filePath);
+            try {
+                SAXReader saxReader = new SAXReader();
+                Document document = saxReader.read(file);
+                Element rootElement = document.getRootElement();
+                Element dependenciesElement = rootElement.element("dependencies");
+                for (Iterator it = dependenciesElement.elementIterator(); it.hasNext(); ) {
+                    Dependency dependency = new Dependency();
+                    Element element = (Element) it.next();
+                    String groupId = element.element("groupId").getText();
+                    String artifactId = element.element("artifactId").getText();
+                    String version = element.element("version") == null ? "" : element.element("version").getText();
+                    String scope = element.element("scope") == null ? "" : element.element("scope").getText();
+                    dependency.setGroupId(groupId);
+                    dependency.setArtifactId(artifactId);
+                    dependency.setVersion(version);
+                    dependency.setScope(scope);
+                    d.add(dependency);
+                }
+
+            } catch (DocumentException e) {
+                e.printStackTrace();
+            }
+        }
+        return d;
+    }
+
+    /**
+     * 根据不同构建工具, 生成依赖文本
+     */
+    private String dependencyTextByType(String type) {
+        if ("Gradle".equals(type)) {
+            return dependencyTextForGradle();
+        }
+        return dependencyTextForMaven();
+    }
+
+    /**
+     * 生成gradle的依赖文本
+     */
     private String dependencyTextForGradle() {
         String dependencyText;
         switch (scope) {
             case "test":
-                dependencyText = String.format("testCompile group: '%s', name: '%s', version: '%s'", groupId, artifactId, version);
+                dependencyText = String.format("testImplementation '%s:%s:%s'", groupId, artifactId, version);
                 break;
             case "provided":
-                dependencyText = String.format("provided group: '%s', name: '%s', version: '%s'", groupId, artifactId, version);
+                dependencyText = String.format("compileOnly '%s:%s:%s'", groupId, artifactId, version);
                 break;
             default:
-                dependencyText = String.format("compile group: '%s', name: '%s', version: '%s'", groupId, artifactId, version);
+                dependencyText = String.format("implementation '%s:%s:%s'", groupId, artifactId, version);
                 break;
         }
         return dependencyText;
+    }
+
+    /**
+     * 生成maven的依赖文本
+     */
+    private String dependencyTextForMaven() {
+        if (scope != null && !scope.equals("")) {
+            return "<dependency>\n" +
+                    "    <groupId>" + groupId + "</groupId>\n" +
+                    "    <artifactId>" + artifactId + "</artifactId>\n" +
+                    "    <version>" + version + "</version>\n" +
+                    "    <scope>" + scope + "</scope>\n" +
+                    "</dependency>";
+        } else {
+            return "<dependency>\n" +
+                    "    <groupId>" + groupId + "</groupId>\n" +
+                    "    <artifactId>" + artifactId + "</artifactId>\n" +
+                    "    <version>" + version + "</version>\n" +
+                    "</dependency>";
+        }
     }
 }

--- a/src/actions/MavenDependencyHelperAction.java
+++ b/src/actions/MavenDependencyHelperAction.java
@@ -140,6 +140,10 @@ public class MavenDependencyHelperAction extends AnAction {
         typeComboBox.setFont(new Font(null, Font.PLAIN, 15));
         typeComboBox.addItem("Maven");
         typeComboBox.addItem("Gradle");
+        typeComboBox.addItem("SBT");
+        typeComboBox.addItem("Ivy");
+        typeComboBox.addItem("Grape");
+        typeComboBox.addItem("Leiningen");
 
         textArea = new JTextArea();
         textArea.setColumns(10);
@@ -418,10 +422,35 @@ public class MavenDependencyHelperAction extends AnAction {
      * 根据不同构建工具, 生成依赖文本
      */
     private String dependencyTextByType(String type) {
-        if ("Gradle".equals(type)) {
-            return dependencyTextForGradle();
+        String text;
+        switch (type) {
+            case "Maven":
+                text = dependencyTextForMaven();
+                break;
+            case "Gradle":
+                text = dependencyTextForGradle();
+                break;
+            case "SBT":
+                text = String.format("libraryDependencies += \"%s\" %s \"%s\" %s \"%s\"",
+                        this.groupId, "%", this.artifactId, "%", this.version);
+                break;
+            case "Ivy":
+                text = String.format("<dependency org=\"%s\" name=\"%s\" rev=\"%s\" />",
+                        this.groupId, this.artifactId, this.version);
+                break;
+            case "Grape":
+                text = String.format("@Grapes(\n" +
+                                "  @Grab(group='junit', module='junit', version='4.13')\n" +
+                                ")",
+                        this.groupId, this.artifactId, this.version);
+                break;
+            case "Leiningen":
+                text = String.format("[%s/%s \"%s\"]", this.groupId, this.artifactId, this.version);
+                break;
+            default:
+                text = "";
         }
-        return dependencyTextForMaven();
+        return text;
     }
 
     /**

--- a/src/actions/MavenDependencyHelperAction.java
+++ b/src/actions/MavenDependencyHelperAction.java
@@ -106,7 +106,7 @@ public class MavenDependencyHelperAction extends AnAction {
      */
     private void initView() {
         frame = new JFrame("Maven Dependency Helper");
-        frame.setSize(525, 250);
+        frame.setSize(520, 240);
         frame.setLocationRelativeTo(null);
         frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
 
@@ -156,7 +156,7 @@ public class MavenDependencyHelperAction extends AnAction {
         versionJList = new JBList<>(versionListModel);
         versionJList.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
         listScroller = new JBScrollPane(versionJList);
-        listScroller.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_ALWAYS);
+        listScroller.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
         listScroller.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_ALWAYS);
 
         versionJList.addListSelectionListener(versionJListSelectionListener);
@@ -193,14 +193,14 @@ public class MavenDependencyHelperAction extends AnAction {
      * 设置组件的位置和大小
      */
     private void setLocationAndSize() {
-        comboBox.setBounds(20, 10, 110, 30);
-        textField.setBounds(190, 10, 300, 30);
-        typeComboBox.setBounds(310, 45, 80, 25);
-        copyVersionButton.setBounds(20, 45, 110, 25);
-        copyTextAeraButton.setBounds(190, 45, 110, 25);
-        searchButton.setBounds(400, 45, 90, 25);
-        listScroller.setBounds(20, 77, 110, 122);
-        scrollPane.setBounds(190, 77, 300, 122);
+        comboBox.setBounds(20, 10, 130, 30);
+        textField.setBounds(170, 10, 330, 30);
+        typeComboBox.setBounds(310, 45, 90, 28);
+        copyVersionButton.setBounds(20, 45, 130, 28);
+        copyTextAeraButton.setBounds(170, 45, 130, 28);
+        searchButton.setBounds(410, 45, 90, 28);
+        listScroller.setBounds(20, 77, 130, 122);
+        scrollPane.setBounds(170, 77, 330, 122);
     }
 
     /**
@@ -303,7 +303,12 @@ public class MavenDependencyHelperAction extends AnAction {
      * @param event event
      */
     private void typeComboBoxItemSelectEvent(ItemEvent event) {
-        if (event.getStateChange() == ItemEvent.SELECTED) {
+        if (event.getStateChange() != ItemEvent.SELECTED) return;
+
+        String version = versionJList.getSelectedValue();
+        if (version == null || version.length() == 0) {
+            textArea.setText("");
+        } else {
             String buildToolType = event.getItem().toString();
             String dependencyText = dependencyTextByType(buildToolType);
             textArea.setText(dependencyText);

--- a/src/model/Artifact.java
+++ b/src/model/Artifact.java
@@ -1,0 +1,34 @@
+package model;
+
+/**
+ * Identify a artifact.
+ */
+public class Artifact {
+
+    private String groupId;
+    private String artifactId;
+
+    public String getGroupId() {
+        return groupId;
+    }
+
+    public void setGroupId(String groupId) {
+        this.groupId = groupId;
+    }
+
+    public String getArtifactId() {
+        return artifactId;
+    }
+
+    public void setArtifactId(String artifactId) {
+        this.artifactId = artifactId;
+    }
+
+    @Override
+    public String toString() {
+        return "ArtifactId{" +
+                "groupId='" + groupId + '\'' +
+                ", artifactId='" + artifactId + '\'' +
+                '}';
+    }
+}

--- a/src/searcher/DependencySearcher.java
+++ b/src/searcher/DependencySearcher.java
@@ -15,7 +15,7 @@ public interface DependencySearcher {
     /**
      * Search dependency.
      */
-    List<Artifact> search(String text) throws Exception;
+    List<Artifact> search(String text) throws IOException;
 
     /**
      * Fetch all version dependency by groupId & articleId.

--- a/src/searcher/DependencySearcher.java
+++ b/src/searcher/DependencySearcher.java
@@ -1,0 +1,25 @@
+package searcher;
+
+import model.Artifact;
+import model.Dependency;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * To search dependency.
+ */
+public interface DependencySearcher {
+
+
+    /**
+     * Search dependency.
+     */
+    List<Artifact> search(String text) throws Exception;
+
+    /**
+     * Fetch all version dependency by groupId & articleId.
+     */
+    List<Dependency> getDependencies(String groupId, String articleId) throws IOException;
+
+}

--- a/src/searcher/MvnRepositoryComDependencySearcher.java
+++ b/src/searcher/MvnRepositoryComDependencySearcher.java
@@ -1,0 +1,59 @@
+package searcher;
+
+import model.Artifact;
+import model.Dependency;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Search dependencies from https://mvnrepository.com
+ * TODO: handle http 503
+ */
+public class MvnRepositoryComDependencySearcher implements DependencySearcher {
+
+    @Override
+    public List<Artifact> search(String text) throws Exception {
+        String searchUrl = "https://mvnrepository.com/search?q=" + text;
+        Document doc = Jsoup.connect(searchUrl).get();
+        Elements elements = doc.getElementsByClass("im-subtitle");
+
+        List<Artifact> artifacts = new ArrayList<>(elements.size());
+        for (Element ele : elements) {
+            Elements hrefs = ele.getElementsByAttribute("href");
+            if (hrefs.size() >= 2) {
+                Artifact artifact = new Artifact();
+                artifact.setGroupId(hrefs.get(0).text());
+                artifact.setGroupId(hrefs.get(1).text());
+            }
+        }
+        return artifacts;
+    }
+
+    @Override
+    public List<Dependency> getDependencies(String groupId, String articleId) throws IOException {
+        String url = String.format("https://mvnrepository.com/artifact/%s/%s", groupId, articleId);
+        Document doc = Jsoup.connect(url)
+//                .cookie("__cfduid", "d2056c86f8ed420230b9bc81de716eec31590713938")
+                .cookie("cf_clearance", "3285a877e4974e241bbaeed2b19b1d7a51bde0ff-1590713923-0-150")
+//                .cookie("MVN_SESSION", "eyJhbGciOiJIUzI1NiJ9.eyJkYXRhIjp7InVpZCI6IjkzZjFmOGMxLWExNDctMTFlYS1iY2RmLWIxN2NkNTgxZDlkOCJ9LCJleHAiOjE2MjIyNTAzNDQsIm5iZiI6MTU5MDcxNDM0NCwiaWF0IjoxNTkwNzE0MzQ0fQ.ChWhbOQGiKQMKSZG_NPzT462B32M79RZ4mWqxnU4y18")
+                .header("user-agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36")
+                .get();
+        Elements elements = doc.getElementsByClass("vbtn release");
+
+        List<Dependency> dependencies = new ArrayList<>(elements.size());
+        for (Element ele : elements) {
+            Dependency dependency = new Dependency();
+            dependency.setGroupId(groupId);
+            dependency.setArtifactId(articleId);
+            dependency.setVersion(ele.text());
+            dependencies.add(dependency);
+        }
+        return dependencies;
+    }
+}

--- a/src/searcher/MvnRepositoryComDependencySearcher.java
+++ b/src/searcher/MvnRepositoryComDependencySearcher.java
@@ -17,10 +17,26 @@ import java.util.List;
  */
 public class MvnRepositoryComDependencySearcher implements DependencySearcher {
 
+    /**
+     * 超时毫秒
+     */
+    private final int timeoutMs;
+
+    public MvnRepositoryComDependencySearcher() {
+        this(30000);
+    }
+
+    public MvnRepositoryComDependencySearcher(int timeoutMs) {
+        if (timeoutMs <= 0) {
+            throw new IllegalArgumentException("timeoutMs must grater than 0");
+        }
+        this.timeoutMs = timeoutMs;
+    }
+
     @Override
-    public List<Artifact> search(String text) throws Exception {
+    public List<Artifact> search(String text) throws IOException {
         String searchUrl = "https://mvnrepository.com/search?q=" + text;
-        Document doc = Jsoup.connect(searchUrl).get();
+        Document doc = Jsoup.connect(searchUrl).timeout(timeoutMs).get();
         Elements elements = doc.getElementsByClass("im-subtitle");
 
         List<Artifact> artifacts = new ArrayList<>(elements.size());
@@ -38,7 +54,7 @@ public class MvnRepositoryComDependencySearcher implements DependencySearcher {
     @Override
     public List<Dependency> getDependencies(String groupId, String articleId) throws IOException {
         String url = String.format("https://mvnrepository.com/artifact/%s/%s", groupId, articleId);
-        Document doc = Jsoup.connect(url)
+        Document doc = Jsoup.connect(url).timeout(timeoutMs)
 //                .cookie("__cfduid", "d2056c86f8ed420230b9bc81de716eec31590713938")
                 .cookie("cf_clearance", "3285a877e4974e241bbaeed2b19b1d7a51bde0ff-1590713923-0-150")
 //                .cookie("MVN_SESSION", "eyJhbGciOiJIUzI1NiJ9.eyJkYXRhIjp7InVpZCI6IjkzZjFmOGMxLWExNDctMTFlYS1iY2RmLWIxN2NkNTgxZDlkOCJ9LCJleHAiOjE2MjIyNTAzNDQsIm5iZiI6MTU5MDcxNDM0NCwiaWF0IjoxNTkwNzE0MzQ0fQ.ChWhbOQGiKQMKSZG_NPzT462B32M79RZ4mWqxnU4y18")

--- a/src/searcher/SearchMavenOrgDependencySearcher.java
+++ b/src/searcher/SearchMavenOrgDependencySearcher.java
@@ -1,0 +1,71 @@
+package searcher;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import model.Artifact;
+import model.Dependency;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Search dependencies by https://search.maven.org/
+ */
+public class SearchMavenOrgDependencySearcher implements DependencySearcher {
+
+    private static final String SEARCH_URL = "https://search.maven.org/solrsearch/select?q=%s&start=0&rows=20";
+
+    @Override
+    public List<Artifact> search(String text) throws Exception {
+        Document document = Jsoup.connect(String.format(SEARCH_URL, encodeUtf8(text))).ignoreContentType(true).get();
+        JsonObject data = new Gson().fromJson(document.body().text(), JsonObject.class);
+        JsonArray docs = data.getAsJsonObject("response").getAsJsonArray("docs");
+
+        List<Artifact> artifacts = new ArrayList<>(docs.size());
+        for (JsonElement ele : docs) {
+            JsonObject doc = ele.getAsJsonObject();
+            Artifact artifact = new Artifact();
+            artifact.setGroupId(doc.get("g").getAsString());
+            artifact.setArtifactId(doc.get("a").getAsString());
+            artifacts.add(artifact);
+        }
+
+        return artifacts;
+    }
+
+    @Override
+    public List<Dependency> getDependencies(String groupId, String articleId) throws IOException {
+        String text = String.format("g:%s AND a:%s", encodeUtf8(groupId), encodeUtf8(articleId)) + "&core=gav";
+        Document document = Jsoup.connect(String.format(SEARCH_URL, text)).ignoreContentType(true).get();
+        JsonObject data = new Gson().fromJson(document.body().text(), JsonObject.class);
+        JsonArray docs = data.getAsJsonObject("response").getAsJsonArray("docs");
+
+        List<Dependency> dependencies = new ArrayList<>(docs.size());
+        for (JsonElement ele : docs) {
+            JsonObject doc = ele.getAsJsonObject();
+            Dependency dependency = new Dependency();
+            dependency.setGroupId(doc.get("g").getAsString());
+            dependency.setArtifactId(doc.get("a").getAsString());
+            dependency.setVersion(doc.get("v").getAsString());
+            dependencies.add(dependency);
+        }
+        return dependencies;
+    }
+
+    private String encodeUtf8(String text) {
+        try {
+            return URLEncoder.encode(text, StandardCharsets.UTF_8.name());
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException("Never happen.", e);
+        }
+
+    }
+}


### PR DESCRIPTION
1. 修改依赖信息抓取来源为:https://search.maven.org
2. 优化事件监听重复注册
3. 优化UI界面对称
4. 添加更多构建工具类型支持